### PR TITLE
Fix xsdata version to requirements

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -6,3 +6,4 @@ numpy==1.23.2
 pandas==1.5.0
 pyMapVBVD==0.4.8
 scipy==1.9.1
+xsdata==23.8


### PR DESCRIPTION
Fixes the #6 
```bash
python main.py --config config/base_config.py
``` 
```bash
I0403 13:32:00.527845 8056085312 subject_classmap.py:34] Reading twix files.
pymapVBVD version 0.4.8
Software version: VD
I0403 13:32:00.699253 8056085312 twix_utils.py:540] Reading in 'normal' dixon data on Siemens Prisma w/ bonus.
pymapVBVD version 0.4.8
Software version: VD
pymapVBVD version 0.4.8
Software version: VD
I0403 13:32:01.103251 8056085312 subject_classmap.py:67] Getting trajectories.
I0403 13:32:01.128476 8056085312 subject_classmap.py:89] Writing MRD files.
# Omitted for simplicity 
  File "/Users/mateus/git/vida/xenon-siemens-to-mrd-consortium/to-test/lib/python3.8/site-packages/xsdata/formats/dataclass/serializers/mixins.py", line 366, in generate
    if isinstance(obj, self.context.class_type.derived_element):
AttributeError: 'SerializerConfig' object has no attribute 'class_type'
```
### This fixes the problem
```bash
echo xsdata==23.8 >> ./setup/requirements.txt
pip install -r setup/requirements.txt
# Omitted for simplicity
Installing collected packages: xsdata
  Attempting uninstall: xsdata
    Found existing installation: xsdata 24.4
    Uninstalling xsdata-24.4:
      Successfully uninstalled xsdata-24.4
Successfully installed xsdata-23.8
``` 
```bash
 python main.py --config config/base_config.py
I0403 13:33:32.712462 8056085312 subject_classmap.py:34] Reading twix files.
pymapVBVD version 0.4.8
Software version: VD
I0403 13:33:32.894193 8056085312 twix_utils.py:540] Reading in 'normal' dixon data on Siemens Prisma w/ bonus.
pymapVBVD version 0.4.8
Software version: VD
pymapVBVD version 0.4.8
Software version: VD
I0403 13:33:33.328186 8056085312 subject_classmap.py:67] Getting trajectories.
I0403 13:33:33.353509 8056085312 subject_classmap.py:89] Writing MRD files.
I0403 13:33:35.634869 8056085312 subject_classmap.py:114] Moving output files to subject directory.
I0403 13:33:35.637850 8056085312 main.py:26] Program complete
```