### PR TITLE
Add github templates to repo

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,22 @@
+title: "[Idea]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    attributes:
+      label: Problem
+      description: What problem does this idea solve?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed solution
+      description: Describe your idea.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you evaluate?

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,24 @@
+title: "[Q&A]: "
+labels:
+  - question
+body:
+  - type: textarea
+    attributes:
+      label: What are you trying to do?
+      description: Describe your goal clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What have you tried?
+      description: Include relevant details, code, or links.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Any other relevant information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: "[Feature]: "
+labels:
+  - enhancement
+assignees: []
+
+body:
+  - type: textarea
+    id: problem_summary
+    attributes:
+      label: Problem Summary
+      description: A clear and concise description of what the problem is.
+      placeholder: |
+        I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you want to happen.
+      placeholder: |
+        The pipeline should...
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Explain why this feature is important.
+      placeholder: |
+        This should be developed because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: (Optional) Add any other context or screenshots about the feature request.
+      placeholder: |
+        You should also know...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/functional-problem.yml
+++ b/.github/ISSUE_TEMPLATE/functional-problem.yml
@@ -1,0 +1,79 @@
+name: Functional Problem
+description: Report bugs to be squashed
+title: "[Bug]: "
+labels:
+  - bug
+assignees: []
+
+body:
+  - type: textarea
+    id: problem_summary
+    attributes:
+      label: Problem Summary
+      description: Explain what isn't working as expected.
+      placeholder: |
+          The pipeline is failing when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Explain why this is a problem.
+      placeholder: |
+          This is a problem because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: |
+          It should be doing...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: How to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+         1. 
+         2. 
+         3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: (Optional) Add screenshots to help explain your problem.
+      placeholder: |
+          Included supplemental text if needed...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: Additional Info
+      description: (Optional) Add any other context about the problem here.
+      placeholder: |
+          You should also know...
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggested_fix
+    attributes:
+      label: Suggested Fix
+      description: (Optional) Share your thoughts, whether technical or abstract.
+      placeholder: |
+          This can be fixed by...
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+## Changes
+
+<!-- What features/files were changed? -->
+
+*
+
+## Testing Instructions
+
+<!-- How do we ensure the code works as expected? -->
+
+1.
+
+## Screenshots (if applicable)


### PR DESCRIPTION
New issue templates to improve our documentation & guide users to write descriptive issue tickets.