### PR TITLE
Added ability to manually input demographics via config

### DIFF
--- a/config/base_config.py
+++ b/config/base_config.py
@@ -19,6 +19,12 @@ class Config(config_dict.ConfigDict):
         multi_echo (str): flag for echo structure 
             (auto, single_echo, single_echo_2, multi_echo, or multi_echo_2)
         patient_demographics (bool): flag whether to write demographics to MRD header
+        patient_height_mm (float): manual input for patient height in mm (optional)
+        patient_weight_kg (float): manual input for patient weight in kg (optional)
+        patient_age (int): manual input for patient age in years (optional)
+        patient_gender_key (str): manual input for patient gender (optional)
+            NONE (default, uses twix header), FEMALE, MALE, OTHER
+
         recon (Recon): object containing reconstruction configurations for trajectory generation
         calibration (Calibration); object containing calibration sequence configurations
         dixon (Dixon): object containing Dixon sequence configurations
@@ -37,11 +43,11 @@ class Config(config_dict.ConfigDict):
         self.multi_echo = "auto"
         self.patient_demographics = False
 
-        # Manual demographics input (optional)
+        # Manual demographics input (optional), default values prompt usage of twix header
         self.patient_height_mm = np.nan
         self.patient_weight_kg = np.nan
         self.patient_age = np.nan
-        self.patient_sex = ""
+        self.patient_gender_key = constants.GenderKey.NONE.value
 
 
 class Recon(object):

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -24,20 +24,11 @@ class Config(config_dict.ConfigDict):
         patient_age (int): manual input for patient age in years (optional)
         patient_gender_key (str): manual input for patient gender (optional)
             NONE (default, uses twix header), FEMALE, MALE, OTHER
-
-        recon (Recon): object containing reconstruction configurations for trajectory generation
-        calibration (Calibration); object containing calibration sequence configurations
-        dixon (Dixon): object containing Dixon sequence configurations
-        proton (Proton): object containing proton sequence configurations
     """
 
     def __init__(self):
         """Initialize config parameters."""
         super().__init__()
-        self.recon = Recon()
-        self.calibration = Calibration()
-        self.dixon = Dixon()
-        self.proton = Proton()
         self.data_dir = ""
         self.subject_id = "test"
         self.multi_echo = "auto"
@@ -48,6 +39,12 @@ class Config(config_dict.ConfigDict):
         self.patient_weight_kg = np.nan
         self.patient_age = np.nan
         self.patient_gender_key = constants.GenderKey.NONE.value
+
+        # Load parameters in config
+        self.recon = Recon()
+        self.calibration = Calibration()
+        self.dixon = Dixon()
+        self.proton = Proton()
 
 
 class Recon(object):

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -38,7 +38,7 @@ class Config(config_dict.ConfigDict):
         self.patient_height_mm = np.nan
         self.patient_weight_kg = np.nan
         self.patient_age = np.nan
-        self.patient_sex = constants.GenderKey.NONE.value
+        self.patient_sex = constants.PatientSexKey.NONE.value
 
         # Load parameters in config
         self.recon = Recon()

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -16,6 +16,9 @@ class Config(config_dict.ConfigDict):
     Attributes:
         data_dir (str): path to the data directory
         subject_id (str): the subject id
+        multi_echo (str): flag for echo structure 
+            (auto, single_echo, single_echo_2, multi_echo, or multi_echo_2)
+        patient_demographics (bool): flag whether to write demographics to MRD header
         recon (Recon): object containing reconstruction configurations for trajectory generation
         calibration (Calibration); object containing calibration sequence configurations
         dixon (Dixon): object containing Dixon sequence configurations
@@ -31,8 +34,14 @@ class Config(config_dict.ConfigDict):
         self.proton = Proton()
         self.data_dir = ""
         self.subject_id = "test"
-        self.multi_echo = "auto" # "single_echo", "single_echo_2", "multi_echo", or "multi_echo_2" or "auto"
-        self.patient_demographics = False 
+        self.multi_echo = "auto"
+        self.patient_demographics = False
+
+        # Manual demographics input (optional)
+        self.patient_height_mm = np.nan
+        self.patient_weight_kg = np.nan
+        self.patient_age = np.nan
+        self.patient_sex = ""
 
 
 class Recon(object):

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -38,7 +38,7 @@ class Config(config_dict.ConfigDict):
         self.patient_height_mm = np.nan
         self.patient_weight_kg = np.nan
         self.patient_age = np.nan
-        self.patient_gender_key = constants.GenderKey.NONE.value
+        self.patient_sex = constants.GenderKey.NONE.value
 
         # Load parameters in config
         self.recon = Recon()

--- a/subject_classmap.py
+++ b/subject_classmap.py
@@ -37,9 +37,7 @@ class Subject(object):
             twix_file_location = io_utils.get_dis_twix_files(str(self.config.data_dir))
             if self.config.multi_echo == "auto":
                 self.config.multi_echo = io_utils.auto_select_gx_protocol(twix_obj=mapvbvd.mapVBVD(twix_file_location))
-            self.dict_dis = io_utils.read_dis_twix(
-                twix_file_location, self.config.multi_echo
-                )
+            self.dict_dis = io_utils.read_dis_twix(twix_file_location, self.config)
             self.dict_dis[constants.IOFields.SUBJECT_ID] = self.config.subject_id
             self.dict_dis[constants.IOFields.GRAD_DELAY_X]= self.config.dixon.gradient_delay_x
             self.dict_dis[constants.IOFields.GRAD_DELAY_Y]= self.config.dixon.gradient_delay_y
@@ -49,17 +47,15 @@ class Subject(object):
             logging.info("Could not find/read Dixon file.")
 
         try:
-            self.dict_dyn = io_utils.read_dyn_twix(
-                io_utils.get_dyn_twix_files(str(self.config.data_dir))
-            )
+            twix_file_location = io_utils.get_dyn_twix_files(str(self.config.data_dir))
+            self.dict_dyn = io_utils.read_dyn_twix(twix_file_location,self.config)
             self.dict_dyn[constants.IOFields.SUBJECT_ID] = self.config.subject_id
         except:
             logging.info("Could not find/read calibration file.")
 
         try:
-            self.dict_proton = io_utils.read_ute_twix(
-                io_utils.get_ute_twix_files(str(self.config.data_dir))
-            )
+            twix_file_location = io_utils.get_ute_twix_files(str(self.config.data_dir))
+            self.dict_proton = io_utils.read_ute_twix(twix_file_location,self.config)
             self.dict_proton[constants.IOFields.SUBJECT_ID] = self.config.subject_id
             self.dict_proton[constants.IOFields.GRAD_DELAY_X]= self.config.proton.gradient_delay_x
             self.dict_proton[constants.IOFields.GRAD_DELAY_Y]= self.config.proton.gradient_delay_y

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -123,6 +123,14 @@ class SystemVendor(enum.Enum):
     SIEMENS = "siemens"
 
 
+class GenderKey(enum.Enum): 
+    """Subject gender"""
+    FEMALE = "F"
+    MALE = "M"
+    OTHER = "O"
+    NONE = ""
+
+
 class TrajType(object):
     """Trajectory type."""
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -123,8 +123,8 @@ class SystemVendor(enum.Enum):
     SIEMENS = "siemens"
 
 
-class GenderKey(enum.Enum): 
-    """Subject gender"""
+class PatientSexKey(enum.Enum): 
+    """Subject sex"""
     FEMALE = "F"
     MALE = "M"
     OTHER = "O"

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -205,7 +205,10 @@ def auto_select_gx_protocol(twix_obj: mapvbvd._attrdict.AttrDict) -> str:
     else:
         raise ValueError(f"Unrecognized length of alTR: {number_of_alTR}. Cannot automatically select GX protocol. Require manual selection")
 
-def read_dyn_twix(path: str) -> Dict[str, Any]:
+def read_dyn_twix(
+        path: str,
+        config: Optional[config_dict.ConfigDict] = None
+    ) -> Dict[str, Any]:
     """Read dynamic spectroscopy twix file.
 
     Args:
@@ -258,14 +261,17 @@ def read_dyn_twix(path: str) -> Dict[str, Any]:
         constants.IOFields.TR_GAS: twix_utils.get_TR_dissolved(twix_obj),
         constants.IOFields.TR_DIS: twix_utils.get_TR_dissolved(twix_obj),
         constants.IOFields.PREP_PULSES: twix_utils.get_prep_pulses(twix_obj),
-        constants.IOFields.PATIENT_BIRTHDAY: twix_utils.get_patient_birthday(twix_obj),
-        constants.IOFields.PATIENT_HEIGHT: twix_utils.get_patient_height(twix_obj),
-        constants.IOFields.PATIENT_SEX: twix_utils.get_patient_sex(twix_obj),
-        constants.IOFields.PATIENT_WEIGHT: twix_utils.get_patient_weight(twix_obj),
+        constants.IOFields.PATIENT_BIRTHDAY: twix_utils.get_patient_birthday(twix_obj, config),
+        constants.IOFields.PATIENT_HEIGHT: twix_utils.get_patient_height(twix_obj, config),
+        constants.IOFields.PATIENT_SEX: twix_utils.get_patient_sex(twix_obj, config),
+        constants.IOFields.PATIENT_WEIGHT: twix_utils.get_patient_weight(twix_obj, config),
     }
 
 
-def read_dis_twix(path: str, multi_echo_flag: str = "single_echo") -> Dict[str, Any]:
+def read_dis_twix(
+        path: str, 
+        config: Optional[config_dict.ConfigDict] = None
+    ) -> Dict[str, Any]:
     """Read dixon disssolved phase imaging twix file.
 
     Args:
@@ -283,12 +289,12 @@ def read_dis_twix(path: str, multi_echo_flag: str = "single_echo") -> Dict[str, 
     twix_obj.image.flagRemoveOS = False
     
     # read gx data
-    if multi_echo_flag == "multi_echo_2":
+    if config.multi_echo == "multi_echo_2":
         data_dict = twix_utils.get_gx_data_multi_echo_2(twix_obj=twix_obj)
-    elif multi_echo_flag == "multi_echo":
+    elif config.multi_echo == "multi_echo":
         data_dict = twix_utils.get_gx_data_multi_echo(twix_obj=twix_obj)
-    elif "single_echo" in multi_echo_flag:
-        data_dict = twix_utils.get_gx_data(twix_obj=twix_obj,multi_echo_flag=multi_echo_flag)
+    elif "single_echo" in config.multi_echo:
+        data_dict = twix_utils.get_gx_data(twix_obj=twix_obj,multi_echo_flag=config.multi_echo)
     else:
         raise ValueError("Could not read gas exchange data.")
     filename = os.path.basename(path)
@@ -305,9 +311,9 @@ def read_dis_twix(path: str, multi_echo_flag: str = "single_echo") -> Dict[str, 
             constants.IOFields.BONUS_SPECTRA_LABELS
         ],
         constants.IOFields.SAMPLE_TIME: twix_utils.get_dwell_time(twix_obj),
-        constants.IOFields.SAMPLE_TIME_BONUS_SPECTRA: twix_utils.get_dwell_time_bonus_spectra(twix_obj,multi_echo_flag),
-        constants.IOFields.FA_DIS: twix_utils.get_flipangle_dissolved(twix_obj,multi_echo_flag),
-        constants.IOFields.FA_GAS: twix_utils.get_flipangle_gas(twix_obj,multi_echo_flag),
+        constants.IOFields.SAMPLE_TIME_BONUS_SPECTRA: twix_utils.get_dwell_time_bonus_spectra(twix_obj,config.multi_echo),
+        constants.IOFields.FA_DIS: twix_utils.get_flipangle_dissolved(twix_obj,config.multi_echo),
+        constants.IOFields.FA_GAS: twix_utils.get_flipangle_gas(twix_obj,config.multi_echo),
         constants.IOFields.FIELD_STRENGTH: twix_utils.get_field_strength(twix_obj),
         constants.IOFields.FIDS: data_dict[constants.IOFields.FIDS],
         constants.IOFields.FIDS_DIS: data_dict[constants.IOFields.FIDS_DIS],
@@ -320,7 +326,7 @@ def read_dis_twix(path: str, multi_echo_flag: str = "single_echo") -> Dict[str, 
         constants.IOFields.INSTITUTION: twix_utils.get_institution(twix_obj),
         constants.IOFields.N_FRAMES: data_dict[constants.IOFields.N_FRAMES],
         constants.IOFields.N_POINTS: twix_utils.get_gas_exchange_npoints(twix_obj), 
-        constants.IOFields.N_POINTS_BONUS_SPECTRA :twix_utils.get_bonus_spectra_npoints(twix_obj,multi_echo_flag),
+        constants.IOFields.N_POINTS_BONUS_SPECTRA :twix_utils.get_bonus_spectra_npoints(twix_obj,config.multi_echo),
         constants.IOFields.ORIENTATION: twix_utils.get_orientation(twix_obj),
         constants.IOFields.PROTOCOL_NAME: twix_utils.get_protocol_name(twix_obj),
         constants.IOFields.RAMP_TIME: twix_utils.get_ramp_time(twix_obj),
@@ -328,7 +334,7 @@ def read_dis_twix(path: str, multi_echo_flag: str = "single_echo") -> Dict[str, 
         constants.IOFields.SCAN_DATE: twix_utils.get_scan_date(twix_obj),
         constants.IOFields.SYSTEM_VENDOR: twix_utils.get_system_vendor(twix_obj),
         constants.IOFields.SOFTWARE_VERSION: twix_utils.get_software_version(twix_obj),
-        constants.IOFields.TE: twix_utils.get_TE(twix_obj,multi_echo_flag),
+        constants.IOFields.TE: twix_utils.get_TE(twix_obj,config.multi_echo),
         constants.IOFields.TR_GAS: twix_utils.get_TR_dissolved(twix_obj),
         constants.IOFields.TR_DIS: twix_utils.get_TR_dissolved(twix_obj),
         constants.IOFields.BANDWIDTH: twix_utils.get_bandwidth(
@@ -337,13 +343,16 @@ def read_dis_twix(path: str, multi_echo_flag: str = "single_echo") -> Dict[str, 
         constants.IOFields.N_ECHO_DIS: data_dict[constants.IOFields.N_ECHO_DIS],
         constants.IOFields.N_ECHO_GAS: data_dict[constants.IOFields.N_ECHO_GAS],
         constants.IOFields.PREP_PULSES: twix_utils.get_prep_pulses(twix_obj),
-        constants.IOFields.PATIENT_BIRTHDAY: twix_utils.get_patient_birthday(twix_obj),
-        constants.IOFields.PATIENT_HEIGHT: twix_utils.get_patient_height(twix_obj),
-        constants.IOFields.PATIENT_SEX: twix_utils.get_patient_sex(twix_obj),
-        constants.IOFields.PATIENT_WEIGHT: twix_utils.get_patient_weight(twix_obj),
+        constants.IOFields.PATIENT_BIRTHDAY: twix_utils.get_patient_birthday(twix_obj, config),
+        constants.IOFields.PATIENT_HEIGHT: twix_utils.get_patient_height(twix_obj, config),
+        constants.IOFields.PATIENT_SEX: twix_utils.get_patient_sex(twix_obj, config),
+        constants.IOFields.PATIENT_WEIGHT: twix_utils.get_patient_weight(twix_obj, config),
     }
 
-def read_ute_twix(path: str) -> Dict[str, Any]:
+def read_ute_twix(
+        path: str,
+        config: Optional[config_dict.ConfigDict] = None
+    ) -> Dict[str, Any]:
     """Read proton ute imaging twix file.
 
     Args:
@@ -398,10 +407,10 @@ def read_ute_twix(path: str) -> Dict[str, Any]:
         constants.IOFields.TE: twix_utils.get_TE(twix_obj),
         constants.IOFields.TR_PROTON: twix_utils.get_TR(twix_obj),
         constants.IOFields.PREP_PULSES: twix_utils.get_prep_pulses(twix_obj),
-        constants.IOFields.PATIENT_BIRTHDAY: twix_utils.get_patient_birthday(twix_obj),
-        constants.IOFields.PATIENT_HEIGHT: twix_utils.get_patient_height(twix_obj),
-        constants.IOFields.PATIENT_SEX: twix_utils.get_patient_sex(twix_obj),
-        constants.IOFields.PATIENT_WEIGHT: twix_utils.get_patient_weight(twix_obj),
+        constants.IOFields.PATIENT_BIRTHDAY: twix_utils.get_patient_birthday(twix_obj, config),
+        constants.IOFields.PATIENT_HEIGHT: twix_utils.get_patient_height(twix_obj, config),
+        constants.IOFields.PATIENT_SEX: twix_utils.get_patient_sex(twix_obj, config),
+        constants.IOFields.PATIENT_WEIGHT: twix_utils.get_patient_weight(twix_obj, config),
     }
 
 

--- a/utils/twix_utils.py
+++ b/utils/twix_utils.py
@@ -102,7 +102,7 @@ def get_patient_birthday(twix_obj: mapvbvd._attrdict.AttrDict, config) -> str:
     scan_year = int(scan_date[:4])
 
     try:
-        patient_age = config.patient_age
+        patient_age = int(config.patient_age)
     except:
         patient_age = np.nan
     
@@ -133,7 +133,7 @@ def get_patient_sex(twix_obj: mapvbvd._attrdict.AttrDict, config) -> str:
         elif patient_sex == 2:
             return "male"
 
-    return patient_sex.lower()
+    return patient_sex
 
 
 def get_dwell_time(twix_obj: mapvbvd._attrdict.AttrDict) -> float:

--- a/utils/twix_utils.py
+++ b/utils/twix_utils.py
@@ -52,7 +52,7 @@ def get_institution(twix_obj: mapvbvd._attrdict.AttrDict) -> str:
     return twix_obj.hdr.Dicom.InstitutionName
 
 
-def get_patient_weight(twix_obj: mapvbvd._attrdict.AttrDict) -> float:
+def get_patient_weight(twix_obj: mapvbvd._attrdict.AttrDict, config) -> float:
     """Get patient weight
     
     Args:
@@ -60,10 +60,18 @@ def get_patient_weight(twix_obj: mapvbvd._attrdict.AttrDict) -> float:
     Returns:
         patient weight in kg
     """
-    return twix_obj.hdr.Dicom.flUsedPatientWeight
+    try:
+        patient_weight = config.patient_weight_kg
+    except:
+        patient_weight = np.nan
+
+    if np.isnan(patient_weight):
+        return twix_obj.hdr.Dicom.flUsedPatientWeight
+
+    return patient_weight
 
 
-def get_patient_height(twix_obj: mapvbvd._attrdict.AttrDict) -> float:
+def get_patient_height(twix_obj: mapvbvd._attrdict.AttrDict, config) -> float:
     """Get patient height
     
     Args:
@@ -71,10 +79,18 @@ def get_patient_height(twix_obj: mapvbvd._attrdict.AttrDict) -> float:
     Returns:
         patient height in mm
     """
-    return twix_obj.hdr.Dicom.flPatientHeight
+    try:
+        patient_height = config.patient_height_mm
+    except:
+        patient_height = np.nan
+
+    if np.isnan(patient_height):
+        return twix_obj.hdr.Dicom.flPatientHeight
+
+    return patient_height
 
 
-def get_patient_birthday(twix_obj: mapvbvd._attrdict.AttrDict) -> str:
+def get_patient_birthday(twix_obj: mapvbvd._attrdict.AttrDict, config) -> str:
     """Get patient birthday (rough estimate using Jan 01 for given birth year)
     
     Args:
@@ -82,14 +98,22 @@ def get_patient_birthday(twix_obj: mapvbvd._attrdict.AttrDict) -> str:
     Returns:
         patient birthday as a string
     """
-    patient_age = int(twix_obj.hdr.Dicom.flPatientAge)
     scan_date = get_scan_date(twix_obj=twix_obj)
     scan_year = int(scan_date[:4])
-    patient_birthday = str(scan_year-patient_age) + "-01-01"
-    return patient_birthday
+
+    try:
+        patient_age = config.patient_age
+    except:
+        patient_age = np.nan
+    
+    if np.isnan(patient_age):
+        patient_age = int(twix_obj.hdr.Dicom.flPatientAge)
+        return str(scan_year-patient_age) + "-01-01"
+
+    return str(scan_year-patient_age) + "-01-01"
 
 
-def get_patient_sex(twix_obj: mapvbvd._attrdict.AttrDict) -> str:
+def get_patient_sex(twix_obj: mapvbvd._attrdict.AttrDict, config) -> str:
     """Get patient sex
     
     Args: 
@@ -97,11 +121,19 @@ def get_patient_sex(twix_obj: mapvbvd._attrdict.AttrDict) -> str:
     Returns:
         patient sex
     """
-    patient_sex = twix_obj.hdr.Config.PatientSex
-    if patient_sex == 1:
-        return "female"
-    elif patient_sex == 2:
-        return "male"
+    try:
+        patient_sex = config.patient_sex
+    except:
+        patient_sex = ""
+    
+    if not patient_sex.strip():
+        patient_sex = twix_obj.hdr.Config.PatientSex
+        if patient_sex == 1:
+            return "female"
+        elif patient_sex == 2:
+            return "male"
+
+    return patient_sex.lower()
 
 
 def get_dwell_time(twix_obj: mapvbvd._attrdict.AttrDict) -> float:

--- a/utils/twix_utils.py
+++ b/utils/twix_utils.py
@@ -335,10 +335,10 @@ def get_prep_pulses(twix_obj: mapvbvd._attrdict.AttrDict) -> bool:
     	flag indicating prep pulses were used
     """
     try:
-    	if twix_obj.hdr.Phoenix["sWipMemBlock", "alFree", "15"] > 0:
-    		return True
-    	else:
-    		return False
+        if twix_obj.hdr.Phoenix["sWipMemBlock", "alFree", "15"] > 0:
+            return True
+        else:
+            return False
     except:
     	return False
 


### PR DESCRIPTION
## Summary

This PR allows for the user to manually set patient demographics in the config file. If an old config file is used (i.e., doesn't have new config flags), the pipeline will default to reading from the twix header. If the user has the new flags but doesn't set them from the default setting in base_config, the pipeline will default to reading from the twix header. The user may also specify one or two using the config, and leaving the others not changed from default will read from the twix header. 

## Changes

- base_config.py - added fields for manual input of patient height, weight, age, and sex
- subject_classmap.py - added subject config into the input parameters for twix file reading; this allows the read-in functions to check if parameters were manually set in the config
- io_utils.py - added a config input parameter to the read-in functions; added config input parameters when calling the twix_utils functions that get the actual demographics
- twix_utils.py - changed get_patient_weight, ...height, ...birthday, and ...sex to first try to read demographics from the config file and default to the twix header if missing or unchanged. 

## Testing Instructions

1. In subject config file, set `self.patient_demographics = True`
2. Run conversion without changing default values (resulting MRD demographics should match twix header)
3. Manually set patient demographics in the config file and run conversion again (resulting MRD demographics should match config file)
4. Run a conversion using an old config file that doesn't have the optional manual inputs and ensure conversion still reads demographics from the twix header

Pro tips: 
- When testing manual demographics, set them to values different than the twix header to ensure you can tell it pulled from the config file
- To check the **MRD** header, open the file in a text editor and Cmd+F search for "patientWeight_kg", "patientHeight_m", "patientBirthdate", or "patientGender"
- To check the **twix** header, open the file in a text editor and Cmd+F search for "flUsedPatientWeight", "flPatientHeight", "PatientBirthday", or "PatientSex"