### PR TITLE
Changed male/female to M/F

### DIFF
--- a/utils/twix_utils.py
+++ b/utils/twix_utils.py
@@ -129,9 +129,9 @@ def get_patient_sex(twix_obj: mapvbvd._attrdict.AttrDict, config) -> str:
     if not patient_sex.strip():
         patient_sex = twix_obj.hdr.Config.PatientSex
         if patient_sex == 1:
-            return "female"
+            return "F"
         elif patient_sex == 2:
-            return "male"
+            return "M"
 
     return patient_sex
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

When reading demographics from the twix header, we now write "M" or "F" to the header rather than "male" or "female". 

<!-- What features/files were changed? -->

- twix_utils.py -- now returns "M" or "F" when reading gender from the header

## Testing Instructions

<!-- How do we ensure the code works as expected? -->

1. In subject config file, set `self.patient_demographics` to `True` but leave manual inputs as defaults to read demographics from the header
2. Open MRD file in a text editor
3. Search for "patientGender" and see if it writes "M" or "F"